### PR TITLE
fix: 테마가 idx 내림차순으로 정렬되도록 수정

### DIFF
--- a/soup-search-service/src/main/java/com/kcs/search/controller/BotController.java
+++ b/soup-search-service/src/main/java/com/kcs/search/controller/BotController.java
@@ -27,7 +27,7 @@ public class BotController {
 
     @GetMapping("/collections")
     public ResponseEntity<BaseResponse> searchCollections() {
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("idx").descending());
         List<BotThemeListResponse> themeList = botService.findThemeList(pageable);
         return ResponseEntity.ok(new BaseResponse(200, "성공", themeList));
     }

--- a/soup-search-service/src/main/java/com/kcs/search/controller/MainController.java
+++ b/soup-search-service/src/main/java/com/kcs/search/controller/MainController.java
@@ -31,7 +31,7 @@ public class MainController {
 
     @GetMapping("/search/main")
     public ResponseEntity<BaseResponse> searchMain() {
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("idx").descending());
         List<MainThemeResponse> themeList = collectionService.findThemeList(pageable);
         boolean isUserBest = searchService.isUserDataExist();
         List<Product> prdList;


### PR DESCRIPTION
- data.sql의 실행에 의해 테마 정보가 저장된다.
- 이떄 createdat 값이 모두 동시간으로 찍히게 되므로 기존에 createdat, desc 순으로 정렬하던 것이 무의미해진다.
- 따라서, createdat, desc 순을 idx, desc 순으로 변경한다.